### PR TITLE
Connected the front end `employee.handlebars` to the `employee` home-route to populate the page with existing unacknowledged and acknowledged writeups

### DIFF
--- a/controllers/api/user-routes.js
+++ b/controllers/api/user-routes.js
@@ -17,6 +17,25 @@ router.get('/checkwriteups', async (req, res) => {
     }
 });
 
+// 
+router.get('/checkwriteups-comment', async (req, res) => {
+    try {
+        const writeups = await Writeup.findAll({
+            where: { user_id: req.body.id},
+            include: [
+                {
+                    model: Comment,
+                    attributes: ['content', 'user_id']
+                }
+            ]
+        })
+        res.status(200).json(writeups);
+    } catch (err) {
+        res.status(402).json(err);
+    }
+});
+
+
 //login route that redirects to employee or manager page based on user.position
 router.post('/login', passport.authenticate('local'), async (req, res) => {
     //17-26 were only working in insomnia and i dont use this anymore but it shouldt stop anything from working

--- a/controllers/api/user-routes.js
+++ b/controllers/api/user-routes.js
@@ -17,7 +17,7 @@ router.get('/checkwriteups', async (req, res) => {
     }
 });
 
-// 
+// FOR TESTING: Check up route to retrieve writeups and their nested comments
 router.get('/checkwriteups-comment', async (req, res) => {
     try {
         const writeups = await Writeup.findAll({

--- a/controllers/home-routes.js
+++ b/controllers/home-routes.js
@@ -40,7 +40,9 @@ router.get('/employee', async (req, res) => {
             where: {user_id: req.user.id},
             include: [{model: User}]
         })
-    res.render('employee', { username: req.user.username, writeups:userWriteups});
+        // Serialized the data before passing to the template
+        const writeupsData = userWriteups.map((writeup) => writeup.get({ plain: true }));
+    res.render('employee', { username: req.user.username, writeups: writeupsData});
     } else {
     res.redirect('/dashboard');
     }

--- a/seeds/userData.json
+++ b/seeds/userData.json
@@ -23,5 +23,4 @@
 		"password": "test4568",	
 		"position": 2
 	}
-
 ]

--- a/seeds/writeupData.json
+++ b/seeds/writeupData.json
@@ -19,8 +19,22 @@
 		"reason": "Theft",
 		"content": "Camera displays employee not placing the order through the register",
 		"user_id": 3,
+		"acknowledged": true
+	},
+	{
+		"manager": "jeff",
+		"type": "Warning",
+		"reason": "Attendance",
+		"content": "Did not come in for their shift",
+		"user_id": 3,
+		"acknowledged": false
+	},
+	{
+		"manager": "jeff",
+		"type": "Warning",
+		"reason": "Vulgar language",
+		"content": "Cursed at a guest member",
+		"user_id": 2,
 		"acknowledged": false
 	}
-
-
 ]

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ const path = require('path');
 const express = require('express');
 const exphbs = require('express-handlebars');
 const routes = require('./controllers');
+const helpers = require('./utils/helpers');
 const local = require('./strategies/local');
 const sequelize = require('./config/connection');
 
@@ -9,7 +10,7 @@ const sequelize = require('./config/connection');
 const app = express();
 const PORT = process.env.PORT || 3001;
 
-const hbs = exphbs.create({});
+const hbs = exphbs.create({ helpers });
 
 app.use(require('express-session')
   ({

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -1,0 +1,7 @@
+module.exports = {
+  format_date: (date) => {
+    return `${new Date(date).getMonth() +1}/${new Date(date).getDate()}/${
+      new Date(date).getFullYear()
+    }`;
+  }
+}

--- a/views/employee.handlebars
+++ b/views/employee.handlebars
@@ -6,18 +6,18 @@
 <div class="writeUp">
     <h1>Counseling statements</h1>
     <h3>Need attention:</h3>
-    {{#each writeups}}
+    {{#each writeups as |writeup| }}
     {{#unless acknowledged}}
     <div class="writeupList">
-        <a href="/writeupEMP/{{id}}">{{date_created}}</a>
+        {{> writeup-partial}}
     </div>
     {{/unless}}
     {{/each}}
     <h3>Previous documents:</h3>
-    {{#each writeups}}
+    {{#each writeups as |writeup| }}
     {{#if acknowledged}}
     <div class="writeupList">
-        <a href="/writeupFIN/{{id}}">{{date_created}}</a>
+        {{> writeup-partial}}
     </div>
     {{/if}}
     {{/each}}

--- a/views/partials/writeup-partial.handlebars
+++ b/views/partials/writeup-partial.handlebars
@@ -1,0 +1,1 @@
+<a href="/writeupEMP/{{id}}">{{date_created}}</a>

--- a/views/partials/writeup-partial.handlebars
+++ b/views/partials/writeup-partial.handlebars
@@ -1,1 +1,1 @@
-<a href="/writeupEMP/{{id}}">{{date_created}}</a>
+<a href="/writeupEMP/{{id}}">{{format_date date_created}}</a>

--- a/views/partials/writeup-partial.handlebars
+++ b/views/partials/writeup-partial.handlebars
@@ -1,1 +1,1 @@
-<a href="/writeupEMP/{{id}}">{{format_date date_created}} from {{manager}}</a>
+<a href="/writeupEMP/{{id}}">{{type}}: "{{reason}}" on {{format_date date_created}} from {{manager}}</a>

--- a/views/partials/writeup-partial.handlebars
+++ b/views/partials/writeup-partial.handlebars
@@ -1,1 +1,1 @@
-<a href="/writeupEMP/{{id}}">{{format_date date_created}}</a>
+<a href="/writeupEMP/{{id}}">{{format_date date_created}} from {{manager}}</a>


### PR DESCRIPTION
- In `user-routes.js`
    - Defined a route to retrieve all writeups, by a user's `id`, with their nested comments
- In `home-routes.js`
    - In the `employee` route, serialized the data before passing it through the template
        - Assigned the serialized data to a new variable, `writeupsData`. The named variable that stores data from the query, `userWriteups` was not passed anywhere else in the directory so no conflicts exist.
- Created a new `writeup-partial.handlebars` file to create an anchor link for specific writeups. Within these links, employees can view the writeup type, the reason, its creation, and the manager who wrote the writeup 
- In `employee.handlebars` invoked the newly created `writeup-parial` for each writeup depending on its acknowledgment value
- Defined a new `format_date()` helper function. Can be found in the "utils" directory
    - Imported this helper function in `server.js` and passed it to Handlebars
    - Invoked in `writeup-partial.handlebars` to provide an easily readable date to the user
    
---------------------------

- Added new writeup examples for the seed data. 
    - I changed the "Theft" writeup to have an `acknowledgment` value of `true`. Tests whether these are correctly rendered in different sections
    - I added a new warning to test  when a user has multiple unacknowledged writeups

- IMPORTANT: When seeding the database,  users have been inserted into the table in different orders. As such, users have different `id` values. As a result, every time the database is seeded the writeups are assigned to a different person. This is NOT intentional. 
    - I anticipate that this will not be a concern once the database is organically populated, but it may be something to consider when using the sequentially generated `id` to assign to users. 
    - It is unclear why the users are being inserted into the `User` table in different orders each time
 
---------------------------

We may also consider adding first and last names as properties for employees. This may look more professional when reporting on communications where currently we can only use `username`.

