### PR TITLE
Changed `sequelize.sync`'s `force` option to true to resync the database with the updated models

### DIFF
--- a/server.js
+++ b/server.js
@@ -33,6 +33,6 @@ app.use(express.static(path.join(__dirname, 'public')));
 app.use(routes);
 
 
-sequelize.sync({ force: false }).then(() => {
+sequelize.sync({ force: true }).then(() => {
   app.listen(PORT, () => console.log('Now listening'));
 });


### PR DESCRIPTION
Attempt to remedy deployment issues on Render. Routes currently make references to new columns that are likely missing from the Render database's older models.