### PR TITLE
Addressed server crashes that occurred when visitors, who had not logged in, attempted to visit the `employee` and `manager` endpoints

### DIFF
--- a/controllers/home-routes.js
+++ b/controllers/home-routes.js
@@ -51,26 +51,28 @@ router.get('/dashboard', async (req, res) => {
 
 // Route for Employees
 router.get('/employee', async (req, res) => {
-    // Ensure that the user is not a manager before rendering the page
-    if (req.user.position == 1){
-        const usersData = await User.findAll();
-        // Serialize the data
-        const usersClean = usersData.map((user) => user.get({ plain: true }));
-        // Filters data to only non-manager employees
-        const users = usersClean.filter((user) => user.position == 1);
+    if (req.user){
+        // Ensure that the user is not a manager before rendering the page
+        if (req.user.position == 1){
+            const usersData = await User.findAll();
+            // Serialize the data
+            const usersClean = usersData.map((user) => user.get({ plain: true }));
+            // Filters data to only non-manager employees
+            const users = usersClean.filter((user) => user.position == 1);
 
-        const writeTemp = await Writeup.findAll({
-            where: {user_id: req.user.id},
-            include: [
-                { model: User, attributes: ['username'] },
-                { model: Comment, attributes: ['content', 'user_id', 'writeup_id'],
-                    include: [{model: User, attributes: ['username']}]
-                }
-            ]
-        });
-        const writeClean = writeTemp.map((writeup) => writeup.get({ plain: true }));
-   
-    res.render('employee', { username: req.user.username, id: req.user.id, users, writeups: writeClean});
+            const writeTemp = await Writeup.findAll({
+                where: {user_id: req.user.id},
+                include: [
+                    { model: User, attributes: ['username'] },
+                    { model: Comment, attributes: ['content', 'user_id', 'writeup_id'],
+                        include: [{model: User, attributes: ['username']}]
+                    }
+                ]
+            });
+            const writeClean = writeTemp.map((writeup) => writeup.get({ plain: true }));
+       
+            res.render('employee', { username: req.user.username, id: req.user.id, users, writeups: writeClean});
+        }
     } else {
     res.redirect('/dashboard');
     }

--- a/controllers/home-routes.js
+++ b/controllers/home-routes.js
@@ -81,26 +81,28 @@ router.get('/employee', async (req, res) => {
 //route for managers.
 router.get(`/manager`, async (req, res) => {
     //the if checks if you have the correct credentials. So anything you want to show must be within the if statement
-    if(req.user.position == 2){
-        const usersData = await User.findAll();
-        //scrub headers from the data
-        const usersClean = usersData.map((user) => user.get({ plain: true }));
-        //filter to only employees
-        const users = usersClean.filter((user) => user.position == 1);
+    if (req.user) {
+        if(req.user.position == 2){
+            const usersData = await User.findAll();
+            //scrub headers from the data
+            const usersClean = usersData.map((user) => user.get({ plain: true }));
+            //filter to only employees
+            const users = usersClean.filter((user) => user.position == 1);
 
-        const writeTemp = await Writeup.findAll({
-            include: [
-                { model: User, attributes: ['username'] },
-                { model: Comment, attributes: ['content', 'user_id', 'writeup_id'],
-                    include: [{model: User,attributes: ['username']}]
-                }
-            ]
-        });
-        const writeClean = writeTemp.map((writeup) => writeup.get({ plain: true }));
-        const writeups = writeClean.filter((writeup) => writeup.acknowledged == false);
+            const writeTemp = await Writeup.findAll({
+                include: [
+                    { model: User, attributes: ['username'] },
+                    { model: Comment, attributes: ['content', 'user_id', 'writeup_id'],
+                        include: [{model: User,attributes: ['username']}]
+                    }
+                ]
+            });
+            const writeClean = writeTemp.map((writeup) => writeup.get({ plain: true }));
+            const writeups = writeClean.filter((writeup) => writeup.acknowledged == false);
 
-   
-    res.render('manager', { username: req.user.username, id:req.user.id, users, writeups});
+            res.render('manager', { username: req.user.username, id:req.user.id, users, writeups});
+        }
+        
     } else {
     res.redirect('/dashboard');
     }


### PR DESCRIPTION
- Added a `if (req.user)` condition then nested the `req.user.position` logic within it. 
- If `req.user` is `false`, this suggest that a user has not logged in and thus they will be redirected to `dashboard` which will then route the user to the `login` page.